### PR TITLE
Fix missing Garmin imports

### DIFF
--- a/app/routes/fitness_routes.py
+++ b/app/routes/fitness_routes.py
@@ -3,7 +3,11 @@ from app.services.fitness_service import (
     get_strava_authorization_url,
     handle_strava_callback,
     fetch_strava_activities,
-    process_strava_activity
+    process_strava_activity,
+    get_garmin_authorization_url,
+    handle_garmin_callback,
+    fetch_garmin_activities,
+    process_garmin_activity,
 )
 
 fitness = Blueprint("fitness", __name__)


### PR DESCRIPTION
## Summary
- extend fitness routes to import Garmin integration helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434cb24c28832281d346f88728f3a7